### PR TITLE
Get working build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,7 +54,6 @@ jobs:
           app: pandoc-converter
           projectName: Content Platforms::pandoc-converter
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
-          buildNumber: ${{ env.BUILD_NUMBER }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - run: nix-store --export $(nix-store -qR ./result) > pandoc-converter.closure
 
+      - run: ls -hl pandoc-converter.closure
+
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -55,6 +55,7 @@ jobs:
           projectName: Content Platforms::pandoc-converter
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           buildNumber: ${{ env.BUILD_NUMBER }}
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
           configPath: cdk/cdk.out/riff-raff.yaml
           contentDirectories: |
             cdk.out:


### PR DESCRIPTION
## What does this change?

This PR attempts to get a working github actions build that produces a deployable Riff Raff build. Almost there!

I tested it in CODE by deploying (once I had updated [the amigo recipe](https://amigo.gutools.co.uk/recipes/pandoc-converter-ubuntu-jammy-x86) to install nix, using ssm-ssh to connect to an instance (the auto-scaling group cycles instances because nothing is listening on the right port to make the instances appear healthy, but I had long enough to test before one was pulled out from under me), and then using `sudo nix-store --import < /pandoc-converter/pandoc-converter.closure` followed by running the binary directly at its path in the nix store.

This successfully ran the program, demonstrating that installation had succeeded!

So I'm happy to merge this PR (though there is no Riff Raff Continuous Deployment configured, as it's not ready to deploy to PROD yet). I'll get a server running that passes the healthcheck next, and update the user-data to install and run the app (saving the output to a file to make sure it worked).