### PR TITLE
Run server with servant

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -27,8 +27,6 @@ jobs:
 
       - run: nix-build release.nix
 
-      - run: ./result/bin/PandocConverter < test.md
-
       - run: nix-store --export $(nix-store -qR ./result) > pandoc-converter.closure
 
       - run: ls -hl pandoc-converter.closure

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,8 +29,6 @@ jobs:
 
       - run: nix-store --export $(nix-store -qR ./result) > pandoc-converter.closure
 
-      - run: ls -hl pandoc-converter.closure
-
       - name: Setup Node
         uses: actions/setup-node@v4.0.2
         with:

--- a/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
+++ b/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
@@ -234,10 +234,10 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "GuHttpsEgressSecurityGroupPandocconverterfromPandocConverterLoadBalancerPandocconverterSecurityGroupB57C3E5E90009B760117": {
+    "GuHttpsEgressSecurityGroupPandocconverterfromPandocConverterLoadBalancerPandocconverterSecurityGroupB57C3E5E94826AFC8E94": {
       "Properties": {
         "Description": "Load balancer to target",
-        "FromPort": 9000,
+        "FromPort": 9482,
         "GroupId": {
           "Fn::GetAtt": [
             "GuHttpsEgressSecurityGroupPandocconverter0FC6F0C1",
@@ -251,7 +251,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
             "GroupId",
           ],
         },
-        "ToPort": 9000,
+        "ToPort": 9482,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -440,7 +440,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "LoadBalancerPandocconverterSecurityGrouptoPandocConverterGuHttpsEgressSecurityGroupPandocconverterA5359A009000B6C19B66": {
+    "LoadBalancerPandocconverterSecurityGrouptoPandocConverterGuHttpsEgressSecurityGroupPandocconverterA5359A009482147348C5": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
@@ -449,7 +449,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
             "GroupId",
           ],
         },
-        "FromPort": 9000,
+        "FromPort": 9482,
         "GroupId": {
           "Fn::GetAtt": [
             "LoadBalancerPandocconverterSecurityGroup5752B8E3",
@@ -457,11 +457,11 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
           ],
         },
         "IpProtocol": "tcp",
-        "ToPort": 9000,
+        "ToPort": 9482,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
-    "LoadBalancerPandocconverterSecurityGrouptoPandocConverterWazuhSecurityGroupEAF958DF9000E647C17E": {
+    "LoadBalancerPandocconverterSecurityGrouptoPandocConverterWazuhSecurityGroupEAF958DF948217E9816C": {
       "Properties": {
         "Description": "Load balancer to target",
         "DestinationSecurityGroupId": {
@@ -470,7 +470,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
             "GroupId",
           ],
         },
-        "FromPort": 9000,
+        "FromPort": 9482,
         "GroupId": {
           "Fn::GetAtt": [
             "LoadBalancerPandocconverterSecurityGroup5752B8E3",
@@ -478,7 +478,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
           ],
         },
         "IpProtocol": "tcp",
-        "ToPort": 9000,
+        "ToPort": 9482,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
     },
@@ -584,7 +584,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
         "HealthCheckProtocol": "HTTP",
         "HealthCheckTimeoutSeconds": 5,
         "HealthyThresholdCount": 5,
-        "Port": 9000,
+        "Port": 9482,
         "Protocol": "HTTP",
         "Tags": [
           {
@@ -669,10 +669,10 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
       },
       "Type": "AWS::EC2::SecurityGroup",
     },
-    "WazuhSecurityGroupfromPandocConverterLoadBalancerPandocconverterSecurityGroupB57C3E5E9000C3099E72": {
+    "WazuhSecurityGroupfromPandocConverterLoadBalancerPandocconverterSecurityGroupB57C3E5E9482E1A59F98": {
       "Properties": {
         "Description": "Load balancer to target",
-        "FromPort": 9000,
+        "FromPort": 9482,
         "GroupId": {
           "Fn::GetAtt": [
             "WazuhSecurityGroup",
@@ -686,7 +686,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
             "GroupId",
           ],
         },
-        "ToPort": 9000,
+        "ToPort": 9482,
       },
       "Type": "AWS::EC2::SecurityGroupIngress",
     },
@@ -798,7 +798,7 @@ aws s3 cp 's3://",
                     "Ref": "DistributionBucketName",
                   },
                   "/content-api/TEST/pandoc-converter/pandoc-converter.closure' '/pandoc-converter/pandoc-converter.closure'
-converterPath=$(sudo nix-store --import < /pandoc-converter/pandoc-converter.closure | grep PandocConverter); echo "- hello" | $converterPath/bin/PandocConverter > /pandoc-converter/test-output.json",
+converterPath=$(sudo nix-store --import < /pandoc-converter/pandoc-converter.closure | grep PandocConverter); $converterPath/bin/PandocConverter",
                 ],
               ],
             },

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -16,7 +16,7 @@ export class PandocConverter extends GuStack {
 				scope: AccessScope.PUBLIC,
 			},
 			app: 'pandoc-converter',
-			applicationPort: 9000,
+			applicationPort: 9482,
 			imageRecipe: 'pandoc-converter-ubuntu-jammy-x86',
 			instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.NANO),
 			monitoringConfiguration: { noMonitoring: true },

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -26,7 +26,7 @@ export class PandocConverter extends GuStack {
 			userData: {
 				distributable: {
 					executionStatement:
-						'converterPath=$(sudo nix-store --import < /pandoc-converter/pandoc-converter.closure | grep PandocConverter); echo "- hello" | $converterPath/bin/PandocConverter > /pandoc-converter/test-output.json',
+						'converterPath=$(sudo nix-store --import < /pandoc-converter/pandoc-converter.closure | grep PandocConverter); $converterPath/bin/PandocConverter',
 					fileName: 'pandoc-converter.closure',
 				},
 			},

--- a/pandoc-converter.cabal
+++ b/pandoc-converter.cabal
@@ -25,9 +25,12 @@ executable PandocConverter
         lens,
         megaparsec,
         pandoc,
+        servant-server,
         text,
         time,
         transformers,
+        wai,
+        warp,
 
     hs-source-dirs:   src
     default-language: GHC2021

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,22 +1,40 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DataKinds #-}
 module Main where
 
 import Control.Category ((>>>))
 import Control.Monad.Trans.State.Strict
 import Data.Aeson
 import Data.ByteString.Lazy (toStrict)
+import Data.Functor ((<&>))
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8)
 import Data.Text.IO qualified as T
 import Debug.Trace (trace)
+import Network.Wai
+import Network.Wai.Handler.Warp
+import Servant hiding (Header)
 import Text.Pandoc hiding (trace)
 
 import Composer qualified
-import Data.Functor ((<&>))
 
 main :: IO ()
-main =
+main = run 9123 app
+
+app :: Application
+app = serve converterAPI server
+
+converterAPI :: Proxy ConverterAPI
+converterAPI = Proxy
+
+server :: Server ConverterAPI
+server = return "working, hopefully 🤞"
+
+type ConverterAPI = "healthcheck" :> Get '[PlainText] Text
+
+exampleConversion :: IO ()
+exampleConversion =
   T.getContents
     >>= mdToComposer
     >>= (id

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -30,8 +30,10 @@ converterAPI = Proxy
 
 server :: Server ConverterAPI
 server = return "working, hopefully 🤞"
+  :<|> return "working, hopefully 🤞"
 
-type ConverterAPI = "healthcheck" :> Get '[PlainText] Text
+type ConverterAPI = Get '[PlainText] Text
+  :<|>"healthcheck" :> Get '[PlainText] Text
 
 exampleConversion :: IO ()
 exampleConversion =

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -20,7 +20,7 @@ import Text.Pandoc hiding (trace)
 import Composer qualified
 
 main :: IO ()
-main = run 9123 app
+main = run 9482 app
 
 app :: Application
 app = serve converterAPI server


### PR DESCRIPTION
This PR runs a [servant](https://www.servant.dev/) server which returns placeholder text at the root and at `/healthcheck`, so that the auto-scaling group healthchecks succeed and instances aren’t marked as unhealthy.