### PR TITLE
Specify certificateProps to get working networking

### DIFF
--- a/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
+++ b/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
@@ -9,6 +9,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
       "GuSubnetListParameter",
       "GuEc2App",
       "GuDistributionBucketParameter",
+      "GuCertificate",
       "GuInstanceRole",
       "GuSsmSshPolicy",
       "GuDescribeEC2Policy",
@@ -135,6 +136,41 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
         },
       },
       "Type": "AWS::AutoScaling::AutoScalingGroup",
+    },
+    "CertificatePandocconverterEF39FF61": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "DomainName": "pandoc-converter.gutools.co.uk",
+        "Tags": [
+          {
+            "Key": "App",
+            "Value": "pandoc-converter",
+          },
+          {
+            "Key": "gu:cdk:version",
+            "Value": "TEST",
+          },
+          {
+            "Key": "gu:repo",
+            "Value": "guardian/pandoc-converter",
+          },
+          {
+            "Key": "Name",
+            "Value": "PandocConverter/CertificatePandocconverter",
+          },
+          {
+            "Key": "Stack",
+            "Value": "content-api",
+          },
+          {
+            "Key": "Stage",
+            "Value": "TEST",
+          },
+        ],
+        "ValidationMethod": "DNS",
+      },
+      "Type": "AWS::CertificateManager::Certificate",
+      "UpdateReplacePolicy": "Retain",
     },
     "DescribeEC2PolicyFF5F9295": {
       "Properties": {
@@ -339,6 +375,13 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
     },
     "ListenerPandocconverterF61A52D7": {
       "Properties": {
+        "Certificates": [
+          {
+            "CertificateArn": {
+              "Ref": "CertificatePandocconverterEF39FF61",
+            },
+          },
+        ],
         "DefaultActions": [
           {
             "TargetGroupArn": {
@@ -350,8 +393,9 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
         "LoadBalancerArn": {
           "Ref": "LoadBalancerPandocconverterA9DF7F8D",
         },
-        "Port": 8080,
-        "Protocol": "HTTP",
+        "Port": 443,
+        "Protocol": "HTTPS",
+        "SslPolicy": "ELBSecurityPolicy-TLS13-1-2-2021-06",
       },
       "Type": "AWS::ElasticLoadBalancingV2::Listener",
     },
@@ -412,6 +456,15 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
     "LoadBalancerPandocconverterSecurityGroup5752B8E3": {
       "Properties": {
         "GroupDescription": "Automatically created Security Group for ELB PandocConverterLoadBalancerPandocconverter006202B7",
+        "SecurityGroupIngress": [
+          {
+            "CidrIp": "0.0.0.0/0",
+            "Description": "Allow from anyone on port 443",
+            "FromPort": 443,
+            "IpProtocol": "tcp",
+            "ToPort": 443,
+          },
+        ],
         "Tags": [
           {
             "Key": "App",

--- a/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
+++ b/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
@@ -141,7 +141,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
     "CertificatePandocconverterEF39FF61": {
       "DeletionPolicy": "Retain",
       "Properties": {
-        "DomainName": "pandoc-converter.gutools.co.uk",
+        "DomainName": "pandoc-converter.code.dev-gutools.co.uk",
         "Tags": [
           {
             "Key": "App",
@@ -538,7 +538,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
     },
     "PandocConverterDNS": {
       "Properties": {
-        "Name": "pandoc-converter.gutools.co.uk",
+        "Name": "pandoc-converter.code.dev-gutools.co.uk",
         "RecordType": "CNAME",
         "ResourceRecords": [
           {

--- a/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
+++ b/cdk/lib/__snapshots__/pandoc-converter.test.ts.snap
@@ -24,6 +24,7 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
       "GuApplicationLoadBalancer",
       "GuApplicationTargetGroup",
       "GuHttpsApplicationListener",
+      "GuCname",
     ],
     "gu:cdk:version": "TEST",
   },
@@ -534,6 +535,23 @@ exports[`The PandocConverter stack matches the snapshot 1`] = `
         "ToPort": 9482,
       },
       "Type": "AWS::EC2::SecurityGroupEgress",
+    },
+    "PandocConverterDNS": {
+      "Properties": {
+        "Name": "pandoc-converter.gutools.co.uk",
+        "RecordType": "CNAME",
+        "ResourceRecords": [
+          {
+            "Fn::GetAtt": [
+              "LoadBalancerPandocconverterA9DF7F8D",
+              "DNSName",
+            ],
+          },
+        ],
+        "Stage": "TEST",
+        "TTL": 3600,
+      },
+      "Type": "Guardian::DNS::RecordSet",
     },
     "ParameterStoreReadPandocconverterA144CDA6": {
       "Properties": {

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -17,6 +17,9 @@ export class PandocConverter extends GuStack {
 			},
 			app: 'pandoc-converter',
 			applicationPort: 9482,
+			certificateProps: {
+				domainName: 'pandoc-converter.gutools.co.uk',
+			},
 			imageRecipe: 'pandoc-converter-ubuntu-jammy-x86',
 			instanceType: InstanceType.of(InstanceClass.T3, InstanceSize.NANO),
 			monitoringConfiguration: { noMonitoring: true },

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -15,7 +15,7 @@ export class PandocConverter extends GuStack {
 		super(scope, id, props);
 
 		const domainName =
-			scope.stage === 'PROD'
+			this.stage === 'PROD'
 				? 'pandoc-converter.gutools.co.uk'
 				: 'pandoc-converter.code.dev-gutools.co.uk';
 

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -14,7 +14,10 @@ export class PandocConverter extends GuStack {
 	constructor(scope: App, id: string, props: GuStackProps) {
 		super(scope, id, props);
 
-		const domainName = 'pandoc-converter.gutools.co.uk';
+		const domainName =
+			scope.stage === 'PROD'
+				? 'pandoc-converter.gutools.co.uk'
+				: 'pandoc-converter.code.dev-gutools.co.uk';
 
 		this.converter = new GuEc2App(this, {
 			access: {

--- a/cdk/lib/pandoc-converter.ts
+++ b/cdk/lib/pandoc-converter.ts
@@ -41,7 +41,7 @@ export class PandocConverter extends GuStack {
 		});
 
 		this.cname = new GuCname(this, 'PandocConverterDNS', {
-			app: this.converter,
+			app: 'pandoc-converter',
 			ttl: Duration.hours(1),
 			domainName,
 			resourceRecord: this.converter.loadBalancer.loadBalancerDnsName,

--- a/cdk/tsconfig.json
+++ b/cdk/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "@guardian/tsconfig/tsconfig.json",
   "compilerOptions": {
-    "module": "CommonJS"
+    "module": "CommonJS",
+    "moduleResolution": "node"
   },
   "include": ["lib/**/*", "bin/**/*"],
   "exclude": [


### PR DESCRIPTION
## What does this change?

This PR adds the necessary changes to get the server visible at https://pandoc-converter.gutools.co.uk and https://pandoc-converter.code.dev-gutools.co.uk.

### Certificate props

The default configuration when this is left out didn’t work correctly for me as the networking ended up misconfigured (something expected port 8080 and something else didn’t). Using TLS should fix the problem.

I’ve just chosen a random domain that seems sensible: hopefully there isn’t any additional setup I need to do?

### GuCname

- Was told this would be necessary: think the domain isn’t registered otherwise

### Fix local CDK build

`npm run build` was failing locally (but not in CI?) because of some tsconfig conflict: this update fixes it.